### PR TITLE
Whats changed

### DIFF
--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -16,6 +16,8 @@ let soNearliesOnMainIslandByEntity = {}; // [entity1]={ byEntity: {entity2: [ent
 
 let biggestIsland = [];
 
+let newlyAppearedEntities = [];
+
 let  latestBeforeSecs = 0; // most recent update time
 let earliestAfterSecs = 0; // oldest update time
 

--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -295,16 +295,26 @@ function fetchNewlyAppearedEntities(){
 	// look for entities not in that week but which are in the knownEntities,
 	// hence newEntities
 
-	const afterSecs = earliestAfterSecs - (60 * 60 * 24 * 7); // i.e. one week before prev oldest
+	const  afterSecs = earliestAfterSecs - (60 * 60 * 24 * 7); // i.e. one week before prev oldest
 	const beforeSecs = earliestAfterSecs;
 
 	return getLatestEntitiesMentioned(afterSecs, beforeSecs)
 		.then( deltaEntities => {
-			const newEntities = Object.keys(knownEntities).filter(entity => {
+			const newEntitiesWithCount = Object.keys(knownEntities)
+			.filter(entity => {
 				return ! deltaEntities.hasOwnProperty(entity);
+			})
+			.map( entity => {
+				return [entity, knownEntities[entity] ];
 			});
-			newlyAppearedEntities = newEntities;
-			return newEntities;
+			newEntitiesWithCount.sort( (a,b) => {
+				if     ( a[1] > b[1] ) { return -1; }
+				else if( a[1] < b[1] ) { return +1; }
+				else                   { return  0; }
+			});
+
+			newlyAppearedEntities = newEntitiesWithCount;
+			return newEntitiesWithCount;
 		} )
 		;
 }

--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -929,4 +929,5 @@ module.exports = {
 	logbook     : logbook,
 	ontology    : function() { return ONTOLOGY; },
 	biggestIsland : function(){ return biggestIsland; },
+	newlyAppearedEntities : function(){ return newlyAppearedEntities; },
 };

--- a/index.js
+++ b/index.js
@@ -138,6 +138,10 @@ app.get('/allEntities', (req, res) => {
 	res.json( correlate.allEntities() );
 });
 
+app.get('/newlyAppearedEntities', (req, res) => {
+	res.json( correlate.newlyAppearedEntities() );
+});
+
 app.get('/allEntitiesCountsPairs', (req, res) => {
 	res.json( correlate.allEntitiesCountsPairs() );
 });

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -56,6 +56,7 @@
     <li><a href="/allData" />/allData</a></li>
     <li><a href="/allEntities" />/allEntities</a></li>
     <li><a href="/allEntitiesCountsPairs" />/allEntitiesCountsPairs</a></li>
+    <li><a href="/newlyAppearedEntities" />/newlyAppearedEntities</a></li>
     <li><a href="/allIslands" />/allIslands</a> - sets of entities who can be connected together by a series of correlations.</li>
     <li><a href="/biggestIsland" />/biggestIsland</a> - list of entities on biggest island, sorted by article count.</li>
     <li><a href="/summary" />/summary</a> - stats of data</li>


### PR DESCRIPTION
after every update, articles from the week *before* the current in-memory set are searched for entities, and any in-memory entities which do not crop up in that week before are considered 'new' and available as an endpoint /newlyAppearedEntities