### PR TITLE
include imageUrl in articlesPerLink

### DIFF
--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -581,10 +581,15 @@ function fetchCalcChainWithArticlesBetween(entity1, entity2) {
 				debug('fetchCalcChainWithArticlesBetween: sapiObj: no results[0].results');
 			} else {
 				articles = sapiObj.results[0].results.map(result => {
+					let imageUrl = undefined;
+					if (result.images && result.images.length > 0) {
+						imageUrl = result.images[0].url;
+					}
 					return {
 						id    : result.id,
 						title : result.title.title,
 						initialPubDate : result.lifecycle.initialPublishDateTime,
+						imageUrl : imageUrl,
 					};
 				})
 			}

--- a/bin/lib/fetchContent.js
+++ b/bin/lib/fetchContent.js
@@ -70,7 +70,7 @@ function constructSAPIQuery( params ) {
 		queryString : "",
 	   maxResults : 1,
 		     offset : 0,
-		    aspects : [ "title",  "lifecycle"], // [ "title", "location", "summary", "lifecycle", "metadata"],
+		    aspects : [ "title",  "lifecycle", "images"], // [ "title", "location", "summary", "lifecycle", "metadata"],
 		constraints : [],
 		   ontology : "people",
 	};


### PR DESCRIPTION
includes an imageUrl, if SAPI returns one, for each article. You'll need to check if the field imageUrl is defined. The images are only dinky ones.

{
"entity1": "people:Donald Trump",
"entity2": "people:Robert Lange",
"chain": [
"people:Donald Trump",
"people:Anthony Scaramucci",
"people:Robert Lange"
],
"articlesPerLink": [
[
{
"id": "8d8deb8e-76a1-11e7-a3e8-60495fe6ca71",
"title": "Do not try Trump’s White House intrigues at work",
"initialPubDate": "2017-08-01T13:43:00Z",
"imageUrl": "http://im.media.ft.com/content/images/ca2b93f6-8fbb-4c04-94f3-159360747897.img"
},
{
"id": "f75d1155-6612-36f4-8d79-ac9018815c4d",
"title": "Scaramucci out as White House communications chief",
"initialPubDate": "2017-07-31T18:51:47Z"
},
{...