### PR TITLE
update node version, and make the s3o bypass clearer

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,9 @@ app.get('/__gtg', (req, res) => {
 // these route *do* use s3o
 app.set('json spaces', 2);
 
-if (process.env.BYPASS_TOKEN !== 'true') {
+if (process.env.BYPASS_TOKEN == 'true') {
+  console.log( 'WARNING: env.BYPASS_TOKEN set to "true", so skipping s3o checks' ); 
+} else {
 	app.use(validateRequest);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.446.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.446.0.tgz",
-      "integrity": "sha512-xZ+KrHRrQWZLt/1NZ37pzkRbA1rDfryqvcBw5HanmHfO2d2dJJDzow/dfndd/dJyUVc3VvBLPZRW+ZVeFiLw1w==",
+      "version": "2.447.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.447.0.tgz",
+      "integrity": "sha512-bAnNeYJx8U/SGb0zo13YbYvOmHhN3h+3eagP+X7uVG5kmpJMsEpn1EqZJ/Jby7qEB/DQXFGFUzg5kLt//C37/g==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@financial-times/s3o-middleware": "^3.0.1",
     "assert": "^1.4.1",
-    "aws-sdk": "^2.446.0",
+    "aws-sdk": "^2.447.0",
     "debug": "^2.3.3",
     "dotenv": "^2.0.0",
     "express": "^4.16.4",
@@ -38,6 +38,6 @@
     "xml2js": "^0.4.17"
   },
   "engines": {
-    "node": "> 6.11.0 < 7.0.0"
+    "node": "8.9.x"
   }
 }


### PR DESCRIPTION
# Description

Update node version to fix problem on heroku.
Also make the BYPASS_TOKEN thing clearer (no need to comment out s3o check)

# Implementation

# Screenshot

# .env changes

if you want to avoid any s3o check, set this in .env

BYPASS_TOKEN=true 

# Additional requirements
