### PR TITLE
[FEATURE] Island Stats

### DIFF
--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -941,24 +941,19 @@ function getStatsOfIslandOfEntity(rootIslandEntity){
 	const entities = Object.keys( island ).sort();
 	entities.forEach( entity => {
 		const chainLengthsFrom = calcChainLengthsFrom( entity );
-		let entityDetail = {};
-		if (chainLengthsFrom.chainLengths.length <= 1) {
-			entityDetail = {
-				maxChainLength: 0,
-				numDirectlyConnected: 0,
-				numIndirectlyConnected: 0,
-			}
-		} else {
-			entityDetail = {};
+		const entityDetail = {
+			maxChainLength: 0,
+			numDirectlyConnected: 0,
+			numIndirectlyConnected: 0,
+		};
 
+		if (chainLengthsFrom.chainLengths.length > 1) {
 			entityDetail.maxChainLength = (chainLengthsFrom.chainLengths.length -1);
 			entityDetail.numDirectlyConnected = chainLengthsFrom.chainLengths[1].entities.length;
 
 			if (chainLengthsFrom.chainLengths.length >= 3 ) {
 				entityDetail.numIndirectlyConnected = chainLengthsFrom.chainLengths[2].entities.length;
-			} else {
-				entityDetail.numIndirectlyConnected = 0;
-			}
+			} 
 		}
 
 		entityDetails[entity] = entityDetail;

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ app.get('/__gtg', (req, res) => {
 app.set('json spaces', 2);
 
 if (process.env.BYPASS_TOKEN == 'true') {
-  console.log( 'WARNING: env.BYPASS_TOKEN set to "true", so skipping s3o checks' ); 
+  console.log( 'WARNING: env.BYPASS_TOKEN set to "true", so skipping s3o checks' );
 } else {
 	app.use(validateRequest);
 }
@@ -262,6 +262,16 @@ app.get('/islandOf/:entity', (req, res) => {
 	res.json( {
 		entity,
 		sortedIsland
+	} );
+});
+
+app.get('/statsOfIslandOf/:entity', (req, res) => {
+  const entity = req.params.entity;
+  const statsOfIslandOf = correlate.getStatsOfIslandOfEntity(req.params.entity);
+
+	res.json( {
+		entity,
+		statsOfIslandOf
 	} );
 });
 

--- a/static/index.html
+++ b/static/index.html
@@ -27,6 +27,10 @@
       <ul>
         <li>e.g., <a href="/islandOf/people:Donald Trump" />everyone on Donald Trump's island</a></li>
       </ul>
+      <li>/statsOfIslandOf/:entity</li>
+      <ul>
+        <li>e.g., <a href="/statsOfIslandOf/people:Donald Trump" />stats of Donald Trump's island</a></li>
+      </ul>
       <li>/calcChainBetween/:entity1/:entity2</li>
       <ul>
         <li>e.g., <a href="/calcChainBetween/people:Donald Trump/people:Jeremy Hunt" />chain between people:Donald Trump and people:Jeremy Hunt</a></li>

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -20,6 +20,10 @@
   <ul>
     <li>e.g., <a href="/islandOf/{{entity1}}" />everyone on {{entity1}}'s island</a></li>
   </ul>
+  <li>/statsOfIslandOf/:entity</li>
+  <ul>
+    <li>e.g., <a href="/statsOfIslandOf/{{entity1}}" />stats of everyone on {{entity1}}'s island</a></li>
+  </ul>
   <li>/calcChainBetween/:entity1/:entity2</li>
   <ul>
     <li>e.g., <a href="/calcChainBetween/{{entity1}}/{{entity2}}" />chain between {{entity1}} and {{entity2}}</a></li>


### PR DESCRIPTION
# Description

Exploring the connectivity of everyone on an island, identified by the name of someone on the island, to find the most and least connected people, etc.

Previously we only see the article count, i.e. the number of articles each person has been tagged in.

# Implementation

A new endpoint, /statsOfIslandOf, which calls calcChainLengthsFrom for each entity on the island.

# Screenshot

# .env changes

# Additional requirements
