### PR TITLE
[FIX] allow additional ignoreEntities via env

### DIFF
--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -34,6 +34,20 @@ const ignoreEntities = {
 	'topics:Audio articles' : true,
 };
 
+console.log(`INFO: ignoreEntities: default=${JSON.stringify(Object.keys(ignoreEntities))}`);
+
+// look for any entities specified in env param
+const IGNORE_ENTITIES_CSV = process.env.IGNORE_ENTITIES_CSV || '';
+
+IGNORE_ENTITIES_CSV
+.split(',')
+.map   ( entity => { return entity.trim(); } )
+.filter( entity => { return entity.match(/^[a-zA-Z]+:.+/); } )
+.map   ( entity => {
+	ignoreEntities[entity] = true;
+	console.log(`INFO: IGNORE_ENTITIES_CSV: adding entity=${entity}`);
+});
+
 const AWeekOfSecs = 604800;
 const MAX_INTERVAL_SECS = AWeekOfSecs * 2;
 debug(`startup: MAX_INTERVAL_SECS=${MAX_INTERVAL_SECS}`);
@@ -953,7 +967,7 @@ function getStatsOfIslandOfEntity(rootIslandEntity){
 
 			if (chainLengthsFrom.chainLengths.length >= 3 ) {
 				entityDetail.numIndirectlyConnected = chainLengthsFrom.chainLengths[2].entities.length;
-			} 
+			}
 		}
 
 		entityDetails[entity] = entityDetail;

--- a/bin/lib/correlate.js
+++ b/bin/lib/correlate.js
@@ -41,8 +41,8 @@ const IGNORE_ENTITIES_CSV = process.env.IGNORE_ENTITIES_CSV || '';
 
 IGNORE_ENTITIES_CSV
 .split(',')
-.map   ( entity => { return entity.trim(); } )
-.filter( entity => { return entity.match(/^[a-zA-Z]+:.+/); } )
+.map   ( entity => entity.trim() )
+.filter( entity => entity.match(/^[a-zA-Z]+:.+/) )
 .map   ( entity => {
 	ignoreEntities[entity] = true;
 	console.log(`INFO: IGNORE_ENTITIES_CSV: adding entity=${entity}`);

--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@ app.get('/v2ApiCall/', (req, res) => {
 app.get('/exhaustivelyPainfulDataConsistencyCheck', (req, res) => {
   correlate.exhaustivelyPainfulDataConsistencyCheck()
   .then( obj => {
-    console.log( `exhaustivelyPainfulDataConsistencyCheck: response json: ${JSON.stringify(obj)}`);
+    console.log( `INFO: exhaustivelyPainfulDataConsistencyCheck: response json: ${JSON.stringify(obj)}`);
     res.json( obj );
   })
   .catch( err => {
@@ -388,7 +388,7 @@ app.get('/exhaustivelyPainfulDataConsistencyCheck', (req, res) => {
 
 function startListening(){
 	app.listen(process.env.PORT, function(){
-		console.log('Server is listening on port', process.env.PORT);
+		console.log('INFO: Server is listening on port', process.env.PORT);
 	});
 }
 
@@ -397,7 +397,7 @@ function startup() {
   .then( () => {
     const startupRangeSecs = (process.env.hasOwnProperty('STARTUP_RANGE_SECS'))? parseInt(process.env.STARTUP_RANGE_SECS) : 0;
     if (startupRangeSecs > 0) {
-      console.log(`startup: startupRangeSecs=${startupRangeSecs}`);
+      console.log(`INFO: startup: startupRangeSecs=${startupRangeSecs}`);
     	return correlate.fetchUpdateCorrelationsEarlier(startupRangeSecs);
     } else {
       return { msg: 'startup: no data pre-loaded' };
@@ -415,7 +415,7 @@ function startup() {
 
 function postStartup() {
   const postStartupRangeSecs = (process.env.hasOwnProperty('POST_STARTUP_RANGE_SECS'))? parseInt(process.env.POST_STARTUP_RANGE_SECS) : 0;
-  console.log(`postStartup: postStartupRangeSecs=${postStartupRangeSecs}`);
+  console.log(`INFO: postStartup: postStartupRangeSecs=${postStartupRangeSecs}`);
   return correlate.fetchUpdateCorrelationsEarlier(postStartupRangeSecs)
   .catch( err => {
     throw new Error( `postStartup: err=${err}`);
@@ -427,9 +427,9 @@ function updateEverySoOften(count=0){
   let updateEverySecs = process.env.UPDATE_EVERY_SECS;
   let updateEveryMillis = ((updateEverySecs == '')? 0 : parseInt(updateEverySecs)) * 1000;
   if (updateEveryMillis > 0) {
-    console.log(`updateEverySoOften: next update in ${updateEverySecs} secs.`);
+    console.log(`INFO: updateEverySoOften: next update in ${updateEverySecs} secs.`);
     setTimeout(() => {
-      console.log(`updateEverySoOften: count=${count}, UPDATE_EVERY_SECS=${updateEverySecs}`);
+      console.log(`INFO: updateEverySoOften: count=${count}, UPDATE_EVERY_SECS=${updateEverySecs}`);
       correlate.fetchUpdateCorrelationsLatest()
       .then(summaryData => debug(`updateEverySoOften: fetchUpdateCorrelationsLatest: ${JSON.stringify(summaryData)}`) )
       .then( () => updateEverySoOften(count+1) )
@@ -446,7 +446,7 @@ function updateEverySoOften(count=0){
 startup()
 .then(() => postStartup()        )
 .then(() => updateEverySoOften() )
-.then(() => console.log('full startup completed.') )
+.then(() => console.log('INFO: full startup completed.') )
 .catch( err => {
   console.log(`ERROR: on startup: err=${err}`);
 })


### PR DESCRIPTION
# Description

look for additional ignoreEntities via env, IGNORE_ENTITIES_CSV, 
and tidied up some logging.

Main problem is finding errant authors, not marked up as authors, hence treated as people. 
Can now add them to the env var to be ignored.

# Implementation

Looks for the env var, IGNORE_ENTITIES_CSV, and parses it for well-formed entities ("ONTOLOGY:NAME", e.g. "people:Jo Blogs") to be ignored. NB, won't work so well for entities containing a comma in the NAME.

Discards non-well-formed entity strings.

# Screenshot


# .env changes

(optional) specify any additional entities to be ignored in this env var as a CSV

IGNORE_ENTITIES_CSV=abc,  people:Jo Blogs, test:testing

will add the following to the ignoreEntities object

   * people:Jo Blogs
   * test:testing

# Additional requirements

